### PR TITLE
Fix atom answer of swapping

### DIFF
--- a/16_atoms.clj
+++ b/16_atoms.clj
@@ -21,7 +21,7 @@
   ;        __
   ;        @atomic-clock))
   (= 5 (do
-        (swap! atomic-clock + 4)
+        (swap! atomic-clock + 5)
         @atomic-clock))
 
   "Any number of arguments might happen during a swap"

--- a/16_atoms.clj
+++ b/16_atoms.clj
@@ -36,7 +36,7 @@
   ; (= __ (do
   ;         (compare-and-set! atomic-clock 100 :fin)
   ;         @atomic-clock))
-  (= 20 (do
+  (= 0 (do
           (compare-and-set! atomic-clock 100 :fin)
           @atomic-clock))
 


### PR DESCRIPTION
This fixes will fix the solution of **"Keep taxes out of this: swapping requires no transaction"**
where `atomic-clock` should increment with 5.